### PR TITLE
Fix three code bugs

### DIFF
--- a/tools/perf/scripts/python/exported-sql-viewer.py
+++ b/tools/perf/scripts/python/exported-sql-viewer.py
@@ -100,14 +100,18 @@ import argparse
 import weakref
 import threading
 import string
-try:
-	# Python2
-	import cPickle as pickle
-	# size of pickled integer big enough for record size
-	glb_nsz = 8
-except ImportError:
-	import pickle
-	glb_nsz = 16
+import pickle, io
+import sys as _py_sys
+# size of pickled integer big enough for record size
+glb_nsz = 8 if _py_sys.version_info[0] == 2 else 16
+
+class RestrictedUnpickler(pickle.Unpickler):
+	def find_class(self, module, name):
+		# Disallow loading of any global classes during unpickling
+		raise pickle.UnpicklingError("global class loading is forbidden")
+
+def restricted_loads(data):
+	return RestrictedUnpickler(io.BytesIO(data)).load()
 import re
 import os
 import random
@@ -2724,12 +2728,12 @@ class SQLFetcher(QObject):
 		pos = self.local_tail
 		if len(self.buffer) - pos < glb_nsz:
 			pos = 0
-		n = pickle.loads(self.buffer[pos : pos + glb_nsz])
+		n = restricted_loads(self.buffer[pos : pos + glb_nsz])
 		if n == 0:
 			pos = 0
-			n = pickle.loads(self.buffer[0 : glb_nsz])
+			n = restricted_loads(self.buffer[0 : glb_nsz])
 		pos += glb_nsz
-		obj = pickle.loads(self.buffer[pos : pos + n])
+		obj = restricted_loads(self.buffer[pos : pos + n])
 		self.local_tail = pos + n
 		return obj
 

--- a/tools/testing/selftests/tc-testing/plugin-lib/scapyPlugin.py
+++ b/tools/testing/selftests/tc-testing/plugin-lib/scapyPlugin.py
@@ -17,6 +17,68 @@ except ImportError:
     print("\t\tpip3 install scapy==2.4.2")
     exit(1)
 
+import ast
+import scapy.all as scapy_all
+
+
+def _validate_ast_for_scapy(expr: str) -> ast.AST:
+    tree = ast.parse(expr, mode="eval")
+    allowed_nodes = (
+        ast.Expression,
+        ast.BinOp,
+        ast.Call,
+        ast.Name,
+        ast.Attribute,
+        ast.keyword,
+        ast.Load,
+        ast.Constant,
+        ast.Dict,
+        ast.List,
+        ast.Tuple,
+        ast.UnaryOp,
+        ast.USub,
+        ast.UAdd,
+    )
+    allowed_ops = (ast.Div, ast.Add)
+
+    class Validator(ast.NodeVisitor):
+        def visit(self, node):
+            if not isinstance(node, allowed_nodes):
+                raise ValueError(f"Disallowed syntax in packet expression: {type(node).__name__}")
+            return super().visit(node)
+
+        def visit_BinOp(self, node: ast.BinOp):
+            if not isinstance(node.op, allowed_ops):
+                raise ValueError("Only '/' layering and '+' payload concat are allowed")
+            self.visit(node.left)
+            self.visit(node.right)
+
+        def visit_Name(self, node: ast.Name):
+            if node.id not in dir(scapy_all):
+                # Allow True/False/None used as constants in kwargs
+                if node.id not in {"True", "False", "None"}:
+                    raise ValueError(f"Unknown or disallowed name: {node.id}")
+
+        def visit_Attribute(self, node: ast.Attribute):
+            self.visit(node.value)
+
+        def visit_Call(self, node: ast.Call):
+            self.visit(node.func)
+            for arg in node.args:
+                self.visit(arg)
+            for kw in node.keywords:
+                self.visit(kw.value)
+
+    Validator().visit(tree)
+    return tree
+
+
+def safe_eval_packet(expr: str):
+    tree = _validate_ast_for_scapy(expr)
+    env = {name: getattr(scapy_all, name) for name in dir(scapy_all)}
+    return eval(compile(tree, filename="<packet>", mode="eval"), {"__builtins__": {}}, env)
+
+
 class SubPlugin(TdcPlugin):
     def __init__(self):
         self.sub_class = 'scapy/SubPlugin'
@@ -46,7 +108,7 @@ class SubPlugin(TdcPlugin):
                     .format(self.sub_class))
                 print('{}'.format(missing_keys))
 
-            pkt = eval(scapyinfo['packet'])
+            pkt = safe_eval_packet(scapyinfo['packet'])
             if '$' in scapyinfo['iface']:
                 tpl = Template(scapyinfo['iface'])
                 scapyinfo['iface'] = tpl.safe_substitute(NAMES)

--- a/tools/testing/selftests/x86/bugs/its_permutations.py
+++ b/tools/testing/selftests/x86/bugs/its_permutations.py
@@ -7,6 +7,7 @@
 # like spectre_v2 and retbleed.
 
 import os, sys, subprocess, itertools, re, shutil
+import shlex
 
 test_dir = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, test_dir + '/../../kselftest')
@@ -89,8 +90,8 @@ for combination in combinations:
     command += f" -- {TEST}"
     test_name = f"{bug} {test_params}"
     pretty_print(f'# Testing {test_name}')
-    t =  subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    t.wait()
+    args = shlex.split(command)
+    t =  subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     output, _ = t.communicate()
     if t.returncode == 0:
         ksft.test_result_pass(test_name)


### PR DESCRIPTION
Fix three security vulnerabilities: unsafe `eval()`, insecure `pickle.loads`, and `subprocess.Popen(shell=True)`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c9f8b0d-8057-47f2-98b0-4430d5b0e100">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c9f8b0d-8057-47f2-98b0-4430d5b0e100">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

